### PR TITLE
Replace all occurrences of System.currentTimeMillis() in SASIIndexTest by fixed timestamps (CASSANDRA-16444 - trunk)

### DIFF
--- a/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.cql3.CQLTester;
@@ -123,7 +124,7 @@ public class SASIIndexTest
     @Before
     public void cleanUp()
     {
-        Keyspace.open(KS_NAME).getColumnFamilyStore(CF_NAME).truncateBlocking();
+        cleanupData();
     }
 
     @Test
@@ -2522,11 +2523,15 @@ public class SASIIndexTest
         return store;
     }
 
-    private void cleanupData()
+    private static void cleanupData()
+    {
+        stores().forEach(ColumnFamilyStore::truncateBlocking);
+    }
+
+    private static Stream<ColumnFamilyStore> stores()
     {
         Keyspace ks = Keyspace.open(KS_NAME);
-        ks.getColumnFamilyStore(CF_NAME).truncateBlocking();
-        ks.getColumnFamilyStore(CLUSTERING_CF_NAME_1).truncateBlocking();
+        return ks.getMetadata().tables.stream().map(t -> ks.getColumnFamilyStore(t.name));
     }
 
     private static Set<String> getIndexed(ColumnFamilyStore store, int maxResults, Expression... expressions)

--- a/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
@@ -107,6 +107,8 @@ public class SASIIndexTest
     private static final String STATIC_CF_NAME = "static_sasi_test_cf";
     private static final String FTS_CF_NAME = "full_text_search_sasi_test_cf";
 
+    private long timestamp;
+
     @BeforeClass
     public static void loadSchema() throws ConfigurationException
     {
@@ -124,6 +126,7 @@ public class SASIIndexTest
     @Before
     public void cleanUp()
     {
+        timestamp = 0;
         cleanupData();
     }
 
@@ -145,7 +148,7 @@ public class SASIIndexTest
             put("key4", Pair.create("Jason", 27));
         }};
 
-        ColumnFamilyStore store = loadData(data, 1000, forceFlush);
+        ColumnFamilyStore store = loadData(data, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -195,7 +198,7 @@ public class SASIIndexTest
                 put("key1", Pair.create("  ", 14));
         }};
 
-        ColumnFamilyStore store = loadData(data, 1000, forceFlush);
+        ColumnFamilyStore store = loadData(data, forceFlush);
 
         Set<String> rows= getIndexed(store, 10, buildExpression(UTF8Type.instance.decompose("first_name"), Operator.LIKE_MATCHES, UTF8Type.instance.decompose("doesntmatter")));
         assertRows(rows);
@@ -219,7 +222,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Jason", 27));
         }};
 
-        ColumnFamilyStore store = loadData(data, 1000, forceFlush);
+        ColumnFamilyStore store = loadData(data, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -302,7 +305,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Amiya", 36));
             }};
 
-        loadData(part1, 1000, forceFlush); // first sstable
+        loadData(part1, forceFlush); // first sstable
 
         Map<String, Pair<String, Integer>> part2 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -313,7 +316,7 @@ public class SASIIndexTest
                 put("key9", Pair.create("Amely", 40));
             }};
 
-        loadData(part2, 2000, forceFlush);
+        loadData(part2, forceFlush);
 
         Map<String, Pair<String, Integer>> part3 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -324,7 +327,7 @@ public class SASIIndexTest
                 put("key14", Pair.create("Demario", 28));
             }};
 
-        ColumnFamilyStore store = loadData(part3, 3000, forceFlush);
+        ColumnFamilyStore store = loadData(part3, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -416,7 +419,7 @@ public class SASIIndexTest
                         "help someone.", 27));
             }};
 
-        ColumnFamilyStore store = loadData(part1, 1000, forceFlush);
+        ColumnFamilyStore store = loadData(part1, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -479,7 +482,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Amiya", 36));
         }};
 
-        loadData(part1, 1000, forceFlush); // first sstable
+        loadData(part1, forceFlush); // first sstable
 
         Map<String, Pair<String, Integer>> part2 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -491,7 +494,7 @@ public class SASIIndexTest
                 put("key14", Pair.create(null, 28));
         }};
 
-        loadData(part2, 2000, forceFlush);
+        loadData(part2, forceFlush);
 
         Map<String, Pair<String, Integer>> part3 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -504,7 +507,7 @@ public class SASIIndexTest
                 put("key2", Pair.create("Josephine", -1));
         }};
 
-        ColumnFamilyStore store = loadData(part3, 3000, forceFlush);
+        ColumnFamilyStore store = loadData(part3, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -551,7 +554,7 @@ public class SASIIndexTest
                 put("key2", Pair.create("Frank", -1));
         }};
 
-        store = loadData(part4, 4000, forceFlush);
+        store = loadData(part4, forceFlush);
 
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_MATCHES, UTF8Type.instance.decompose("Susana")),
@@ -637,10 +640,10 @@ public class SASIIndexTest
                 put("key26", Pair.create("Dennis", 32));
         }};
 
-        ColumnFamilyStore store = loadData(part1, 1000, forceFlush);
+        ColumnFamilyStore store = loadData(part1, forceFlush);
 
-        loadData(part2, 2000, forceFlush);
-        loadData(part3, 3000, forceFlush);
+        loadData(part2, forceFlush);
+        loadData(part3, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -863,7 +866,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Amiya", 36));
         }};
 
-        ColumnFamilyStore store = loadData(part1, 1000, forceFlush);
+        ColumnFamilyStore store = loadData(part1, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -893,7 +896,7 @@ public class SASIIndexTest
                 put("key14", Pair.create("Dino", 28));
         }};
 
-        loadData(part2, 2000, forceFlush);
+        loadData(part2, forceFlush);
 
         rows = getIndexed(store, 10, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         assertRows(rows, "key6", "key7");
@@ -935,20 +938,20 @@ public class SASIIndexTest
             put("key10", Pair.create("a", 35));
         }};
 
-        ColumnFamilyStore store = loadData(part1, 1000, true);
-        loadData(part2, 2000, true);
-        loadData(part3, 3000, true);
+        ColumnFamilyStore store = loadData(part1, true);
+        loadData(part2, true);
+        loadData(part3, true);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
 
         Set<String> rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         assertRowsSize(rows, 6);
 
-        loadData(part4, 4000, true);
+        loadData(part4, true);
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         assertRowsSize(rows, 8);
 
-        loadData(part5, 5000, true);
+        loadData(part5, true);
 
         int minIndexInterval = store.metadata().params.minIndexInterval;
         try
@@ -1018,10 +1021,10 @@ public class SASIIndexTest
                 put("key26", Pair.create("Dennis", 32));
         }};
 
-        ColumnFamilyStore store = loadData(part1, 1000, true);
+        ColumnFamilyStore store = loadData(part1, true, 2);
 
-        loadData(part2, 2000, true);
-        loadData(part3, 3000, true);
+        loadData(part2, true, 4);
+        loadData(part3, true, 6);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
 
@@ -1029,22 +1032,22 @@ public class SASIIndexTest
         assertRowsSize(rows, 16);
 
         // make sure we don't prematurely delete anything
-        store.indexManager.truncateAllIndexesBlocking(500);
+        store.indexManager.truncateAllIndexesBlocking(1);
 
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         assertRowsSize(rows, 16);
 
-        store.indexManager.truncateAllIndexesBlocking(1500);
+        store.indexManager.truncateAllIndexesBlocking(3);
 
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         assertRowsSize(rows, 10);
 
-        store.indexManager.truncateAllIndexesBlocking(2500);
+        store.indexManager.truncateAllIndexesBlocking(5);
 
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         assertRowsSize(rows, 6);
 
-        store.indexManager.truncateAllIndexesBlocking(3500);
+        store.indexManager.truncateAllIndexesBlocking(7);
 
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         assertRowsSize(rows, 0);
@@ -1056,12 +1059,11 @@ public class SASIIndexTest
                 put("key41", Pair.create("Dennis", 32));
         }};
 
-        loadData(part4, 4000, true);
+        loadData(part4, true, 8);
 
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         assertRowsSize(rows, 1);
     }
-
 
     @Test
     public void testConcurrentMemtableReadsAndWrites() throws Exception
@@ -1138,7 +1140,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Jason", 27));
         }};
 
-        ColumnFamilyStore store = loadData(data1, 1000, true);
+        ColumnFamilyStore store = loadData(data1, true);
 
         Map<String, Pair<String, Integer>> data2 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -1147,7 +1149,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Jason", 28));
         }};
 
-        loadData(data2, 2000, true);
+        loadData(data2, true);
 
         Map<String, Pair<String, Integer>> data3 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -1155,7 +1157,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Jason", 29));
         }};
 
-        loadData(data3, 3000, false);
+        loadData(data3, false);
 
         Set<String> rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         assertRows(rows, "key1", "key2", "key3", "key4");
@@ -1365,7 +1367,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Jason", 27));
         }};
 
-        ColumnFamilyStore store = loadData(data1, 1000, true);
+        ColumnFamilyStore store = loadData(data1, true);
 
         RowFilter filter = RowFilter.create();
         filter.add(store.metadata().getColumn(firstName), Operator.LIKE_CONTAINS, AsciiType.instance.fromString("a"));
@@ -2330,7 +2332,7 @@ public class SASIIndexTest
         ColumnFamilyStore store = loadData(new HashMap<String, Pair<String, Integer>>()
         {{
             put("key1", Pair.create("Pavel", 14));
-        }}, 1000, false);
+        }}, false);
 
         ColumnIndex index = ((SASIIndex) store.indexManager.getIndexByName(store.name + "_first_name")).getIndex();
         IndexMemtable beforeFlushMemtable = index.getCurrentMemtable();
@@ -2361,7 +2363,7 @@ public class SASIIndexTest
         loadData(new HashMap<String, Pair<String, Integer>>()
         {{
             put("key2", Pair.create("Sam", 15));
-        }}, 2000, false);
+        }}, false);
 
         expression = new org.apache.cassandra.index.sasi.plan.Expression(controller, index)
                         .add(Operator.LIKE_MATCHES, UTF8Type.instance.fromString("Sam"));
@@ -2387,7 +2389,7 @@ public class SASIIndexTest
         loadData(new HashMap<String, Pair<String, Integer>>()
         {{
             put("key3", Pair.create("Jonathan", 16));
-        }}, 3000, false);
+        }}, false);
 
         expression = new org.apache.cassandra.index.sasi.plan.Expression(controller, index)
                 .add(Operator.LIKE_MATCHES, UTF8Type.instance.fromString("Jonathan"));
@@ -2484,7 +2486,12 @@ public class SASIIndexTest
         });
     }
 
-    private static ColumnFamilyStore loadData(Map<String, Pair<String, Integer>> data, long timestamp, boolean forceFlush)
+    private ColumnFamilyStore loadData(Map<String, Pair<String, Integer>> data, boolean forceFlush)
+    {
+        return loadData(data, forceFlush, ++timestamp);
+    }
+
+    private ColumnFamilyStore loadData(Map<String, Pair<String, Integer>> data, boolean forceFlush, long timestamp)
     {
         for (Map.Entry<String, Pair<String, Integer>> e : data.entrySet())
             newMutation(e.getKey(), e.getValue().left, null, e.getValue().right, timestamp).apply();

--- a/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
@@ -1178,32 +1178,6 @@ public class SASIIndexTest
     }
 
     @Test
-    public void testInsertingIncorrectValuesIntoAgeIndex()
-    {
-        ColumnFamilyStore store = Keyspace.open(KS_NAME).getColumnFamilyStore(CF_NAME);
-
-        final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
-        final ByteBuffer age = UTF8Type.instance.decompose("age");
-
-        Mutation.PartitionUpdateCollector rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey(AsciiType.instance.decompose("key1")));
-        update(rm, new ArrayList<Cell<?>>()
-        {{
-            add(buildCell(age, LongType.instance.decompose(26L), 1000));
-            add(buildCell(firstName, AsciiType.instance.decompose("pavel"), 1000));
-        }});
-        rm.build().apply();
-
-        store.forceBlockingFlush();
-
-        Set<String> rows = getIndexed(store, 10, buildExpression(firstName, Operator.EQ, UTF8Type.instance.decompose("a")),
-                                                 buildExpression(age, Operator.GTE, Int32Type.instance.decompose(26)));
-
-        // index is expected to have 0 results because age value was of wrong type
-        Assert.assertEquals(0, rows.size());
-    }
-
-
-    @Test
     public void testUnicodeSupport()
     {
         testUnicodeSupport(false);

--- a/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
@@ -84,7 +84,6 @@ import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.Pair;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 
@@ -163,7 +162,7 @@ public class SASIIndexTest
         assertRows(rows, "key4");
 
         rows = getIndexed(store, 10, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("aw")));
-        Assert.assertEquals(rows.toString(), 0, rows.size());
+        assertRowsSize(rows, 0);
 
         rows = getIndexed(store, 10, buildExpression(firstName, Operator.LIKE_SUFFIX, UTF8Type.instance.decompose("avel")));
         assertRows(rows, "key1", "key2", "key3");
@@ -178,7 +177,7 @@ public class SASIIndexTest
         assertRows(rows, "key2");
 
         rows = getIndexed(store, 10, buildExpression(age, Operator.EQ, Int32Type.instance.decompose(13)));
-        Assert.assertEquals(rows.toString(), 0, rows.size());
+        assertRowsSize(rows, 0);
     }
 
     @Test
@@ -345,7 +344,7 @@ public class SASIIndexTest
         rows = getIndexed(store, 5,
                           buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
 
-        Assert.assertEquals(rows.toString(), 5, rows.size());
+        assertRowsSize(rows, 5);
 
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")),
@@ -370,13 +369,13 @@ public class SASIIndexTest
                           buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")),
                           buildExpression(age, Operator.GT, Int32Type.instance.decompose(10)));
 
-        Assert.assertEquals(rows.toString(), 10, rows.size());
+        assertRowsSize(rows, 10);
 
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")),
                           buildExpression(age, Operator.LTE, Int32Type.instance.decompose(50)));
 
-        Assert.assertEquals(rows.toString(), 10, rows.size());
+        assertRowsSize(rows, 10);
 
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_SUFFIX, UTF8Type.instance.decompose("ie")),
@@ -427,12 +426,12 @@ public class SASIIndexTest
                         UTF8Type.instance.decompose("What you get by achieving your goals")),
                 buildExpression(age, Operator.GT, Int32Type.instance.decompose(32)));
 
-        Assert.assertEquals(rows.toString(), Collections.singleton("key1"), rows);
+        assertRows(rows, "key1");
 
         rows = getIndexed(store, 10,
                 buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("do it.")));
 
-        Assert.assertEquals(rows.toString(), Arrays.asList("key0", "key1"), Lists.newArrayList(rows));
+        assertRows(rows, "key0", "key1");
     }
 
     @Test
@@ -524,7 +523,7 @@ public class SASIIndexTest
         rows = getIndexed(store, 5,
                           buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
 
-        Assert.assertEquals(rows.toString(), 5, rows.size());
+        assertRowsSize(rows, 5);
 
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")),
@@ -563,23 +562,23 @@ public class SASIIndexTest
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_MATCHES, UTF8Type.instance.decompose("Demario")),
                           buildExpression(age, Operator.LTE, Int32Type.instance.decompose(30)));
-        Assert.assertEquals(rows.toString(), 0, rows.size());
+        assertRowsSize(rows, 0);
 
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_MATCHES, UTF8Type.instance.decompose("Josephine")));
-        Assert.assertEquals(rows.toString(), 0, rows.size());
+        assertRowsSize(rows, 0);
 
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")),
                           buildExpression(age, Operator.GT, Int32Type.instance.decompose(10)));
 
-        Assert.assertEquals(rows.toString(), 10, rows.size());
+        assertRowsSize(rows, 10);
 
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")),
                           buildExpression(age, Operator.LTE, Int32Type.instance.decompose(50)));
 
-        Assert.assertEquals(rows.toString(), 10, rows.size());
+        assertRowsSize(rows, 10);
 
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_SUFFIX, UTF8Type.instance.decompose("ie")),
@@ -943,11 +942,11 @@ public class SASIIndexTest
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
 
         Set<String> rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
-        Assert.assertEquals(rows.toString(), 6, rows.size());
+        assertRowsSize(rows, 6);
 
         loadData(part4, 4000, true);
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
-        Assert.assertEquals(rows.toString(), 8, rows.size());
+        assertRowsSize(rows, 8);
 
         loadData(part5, 5000, true);
 
@@ -1027,28 +1026,28 @@ public class SASIIndexTest
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
 
         Set<String> rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
-        Assert.assertEquals(rows.toString(), 16, rows.size());
+        assertRowsSize(rows, 16);
 
         // make sure we don't prematurely delete anything
         store.indexManager.truncateAllIndexesBlocking(500);
 
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
-        Assert.assertEquals(rows.toString(), 16, rows.size());
+        assertRowsSize(rows, 16);
 
         store.indexManager.truncateAllIndexesBlocking(1500);
 
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
-        Assert.assertEquals(rows.toString(), 10, rows.size());
+        assertRowsSize(rows, 10);
 
         store.indexManager.truncateAllIndexesBlocking(2500);
 
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
-        Assert.assertEquals(rows.toString(), 6, rows.size());
+        assertRowsSize(rows, 6);
 
         store.indexManager.truncateAllIndexesBlocking(3500);
 
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
-        Assert.assertEquals(rows.toString(), 0, rows.size());
+        assertRowsSize(rows, 0);
 
         // add back in some data just to make sure it all still works
         Map<String, Pair<String, Integer>> part4 = new HashMap<String, Pair<String, Integer>>()
@@ -1060,7 +1059,7 @@ public class SASIIndexTest
         loadData(part4, 4000, true);
 
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
-        Assert.assertEquals(rows.toString(), 1, rows.size());
+        assertRowsSize(rows, 1);
     }
 
 
@@ -2733,6 +2732,13 @@ public class SASIIndexTest
 
     private static void assertRows(Iterable<String> actual, String... expected)
     {
-        Assert.assertArrayEquals(expected, Iterables.toArray(actual, String.class));
+        String message = String.format("Expected rows to contain %s but found %s", Arrays.toString(expected), actual);
+        Assert.assertArrayEquals(message, expected, Iterables.toArray(actual, String.class));
+    }
+
+    private static void assertRowsSize(Set<String> actual, int expectedSize)
+    {
+        String message = String.format("Expected %s to have size %d but found size %d", actual, expectedSize, actual.size());
+        Assert.assertEquals(message, expectedSize, actual.size());
     }
 }

--- a/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
@@ -143,7 +143,7 @@ public class SASIIndexTest
             put("key4", Pair.create("Jason", 27));
         }};
 
-        ColumnFamilyStore store = loadData(data, forceFlush);
+        ColumnFamilyStore store = loadData(data, 1000, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -193,7 +193,7 @@ public class SASIIndexTest
                 put("key1", Pair.create("  ", 14));
         }};
 
-        ColumnFamilyStore store = loadData(data, forceFlush);
+        ColumnFamilyStore store = loadData(data, 1000, forceFlush);
 
         Set<String> rows= getIndexed(store, 10, buildExpression(UTF8Type.instance.decompose("first_name"), Operator.LIKE_MATCHES, UTF8Type.instance.decompose("doesntmatter")));
         Assert.assertTrue(rows.toString(), Arrays.equals(new String[]{}, rows.toArray(new String[rows.size()])));
@@ -217,7 +217,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Jason", 27));
         }};
 
-        ColumnFamilyStore store = loadData(data, forceFlush);
+        ColumnFamilyStore store = loadData(data, 1000, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -300,7 +300,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Amiya", 36));
             }};
 
-        loadData(part1, forceFlush); // first sstable
+        loadData(part1, 1000, forceFlush); // first sstable
 
         Map<String, Pair<String, Integer>> part2 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -311,7 +311,7 @@ public class SASIIndexTest
                 put("key9", Pair.create("Amely", 40));
             }};
 
-        loadData(part2, forceFlush);
+        loadData(part2, 2000, forceFlush);
 
         Map<String, Pair<String, Integer>> part3 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -322,7 +322,7 @@ public class SASIIndexTest
                 put("key14", Pair.create("Demario", 28));
             }};
 
-        ColumnFamilyStore store = loadData(part3, forceFlush);
+        ColumnFamilyStore store = loadData(part3, 3000, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -416,7 +416,7 @@ public class SASIIndexTest
                         "help someone.", 27));
             }};
 
-        ColumnFamilyStore store = loadData(part1, forceFlush);
+        ColumnFamilyStore store = loadData(part1, 1000, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -479,7 +479,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Amiya", 36));
         }};
 
-        loadData(part1, forceFlush); // first sstable
+        loadData(part1, 1000, forceFlush); // first sstable
 
         Map<String, Pair<String, Integer>> part2 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -491,7 +491,7 @@ public class SASIIndexTest
                 put("key14", Pair.create((String)null, 28));
         }};
 
-        loadData(part2, forceFlush);
+        loadData(part2, 2000, forceFlush);
 
         Map<String, Pair<String, Integer>> part3 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -504,7 +504,7 @@ public class SASIIndexTest
                 put("key2", Pair.create("Josephine", -1));
         }};
 
-        ColumnFamilyStore store = loadData(part3, forceFlush);
+        ColumnFamilyStore store = loadData(part3, 3000, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -553,7 +553,7 @@ public class SASIIndexTest
                 put("key2", Pair.create("Frank", -1));
         }};
 
-        store = loadData(part4, forceFlush);
+        store = loadData(part4, 4000, forceFlush);
 
         rows = getIndexed(store, 10,
                           buildExpression(firstName, Operator.LIKE_MATCHES, UTF8Type.instance.decompose("Susana")),
@@ -639,10 +639,10 @@ public class SASIIndexTest
                 put("key26", Pair.create("Dennis", 32));
         }};
 
-        ColumnFamilyStore store = loadData(part1, forceFlush);
+        ColumnFamilyStore store = loadData(part1, 1000, forceFlush);
 
-        loadData(part2, forceFlush);
-        loadData(part3, forceFlush);
+        loadData(part2, 2000, forceFlush);
+        loadData(part3, 3000, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -784,7 +784,7 @@ public class SASIIndexTest
                                                 buildRow(buildCell(store.metadata(),
                                                                    UTF8Type.instance.decompose("/data/output/id"),
                                                                    AsciiType.instance.decompose("jason"),
-                                                                   System.currentTimeMillis()))));
+                                                                   1000))));
 
         Mutation.PartitionUpdateCollector rm2 = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey(AsciiType.instance.decompose("key2")));
         rm2.add(PartitionUpdate.singleRowUpdate(store.metadata(),
@@ -792,7 +792,7 @@ public class SASIIndexTest
                                                 buildRow(buildCell(store.metadata(),
                                                                    UTF8Type.instance.decompose("/data/output/id"),
                                                                    AsciiType.instance.decompose("pavel"),
-                                                                   System.currentTimeMillis()))));
+                                                                   2000))));
 
         Mutation.PartitionUpdateCollector rm3 = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey(AsciiType.instance.decompose("key3")));
         rm3.add(PartitionUpdate.singleRowUpdate(store.metadata(),
@@ -800,7 +800,7 @@ public class SASIIndexTest
                                                 buildRow(buildCell(store.metadata(),
                                                                    UTF8Type.instance.decompose("/data/output/id"),
                                                                    AsciiType.instance.decompose("Aleksey"),
-                                                                   System.currentTimeMillis()))));
+                                                                   3000))));
 
         rm1.build().apply();
         rm2.build().apply();
@@ -865,7 +865,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Amiya", 36));
         }};
 
-        ColumnFamilyStore store = loadData(part1, forceFlush);
+        ColumnFamilyStore store = loadData(part1, 1000, forceFlush);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
         final ByteBuffer age = UTF8Type.instance.decompose("age");
@@ -895,7 +895,7 @@ public class SASIIndexTest
                 put("key14", Pair.create("Dino", 28));
         }};
 
-        loadData(part2, forceFlush);
+        loadData(part2, 2000, forceFlush);
 
         rows = getIndexed(store, 10, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         Assert.assertTrue(rows.toString(), Arrays.equals(new String[]{ "key6", "key7" }, rows.toArray(new String[rows.size()])));
@@ -938,19 +938,19 @@ public class SASIIndexTest
         }};
 
         ColumnFamilyStore store = loadData(part1, 1000, true);
-        loadData(part2, true);
-        loadData(part3, true);
+        loadData(part2, 2000, true);
+        loadData(part3, 3000, true);
 
         final ByteBuffer firstName = UTF8Type.instance.decompose("first_name");
 
         Set<String> rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         Assert.assertEquals(rows.toString(), 6, rows.size());
 
-        loadData(part4, true);
+        loadData(part4, 4000, true);
         rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         Assert.assertEquals(rows.toString(), 8, rows.size());
 
-        loadData(part5, true);
+        loadData(part5, 5000, true);
 
         int minIndexInterval = store.metadata().params.minIndexInterval;
         try
@@ -1080,11 +1080,12 @@ public class SASIIndexTest
             final String key = "key" + i;
             final String firstName = "first_name#" + i;
             final String lastName = "last_name#" + i;
+            final long timestamp = 1000 + i;
 
             scheduler.submit((Runnable) () -> {
                 try
                 {
-                    newMutation(key, firstName, lastName, 26, System.currentTimeMillis()).apply();
+                    newMutation(key, firstName, lastName, 26, timestamp).apply();
                     Uninterruptibles.sleepUninterruptibly(5, TimeUnit.MILLISECONDS); // back up a bit to do more reads
                 }
                 finally
@@ -1139,7 +1140,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Jason", 27));
         }};
 
-        ColumnFamilyStore store = loadData(data1, true);
+        ColumnFamilyStore store = loadData(data1, 1000, true);
 
         Map<String, Pair<String, Integer>> data2 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -1148,7 +1149,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Jason", 28));
         }};
 
-        loadData(data2, true);
+        loadData(data2, 2000, true);
 
         Map<String, Pair<String, Integer>> data3 = new HashMap<String, Pair<String, Integer>>()
         {{
@@ -1156,7 +1157,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Jason", 29));
         }};
 
-        loadData(data3, false);
+        loadData(data3, 3000, false);
 
         Set<String> rows = getIndexed(store, 100, buildExpression(firstName, Operator.LIKE_CONTAINS, UTF8Type.instance.decompose("a")));
         Assert.assertTrue(rows.toString(), Arrays.equals(new String[] { "key1", "key2", "key3", "key4" }, rows.toArray(new String[rows.size()])));
@@ -1189,8 +1190,8 @@ public class SASIIndexTest
         Mutation.PartitionUpdateCollector rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey(AsciiType.instance.decompose("key1")));
         update(rm, new ArrayList<Cell<?>>()
         {{
-            add(buildCell(age, LongType.instance.decompose(26L), System.currentTimeMillis()));
-            add(buildCell(firstName, AsciiType.instance.decompose("pavel"), System.currentTimeMillis()));
+            add(buildCell(age, LongType.instance.decompose(26L), 1000));
+            add(buildCell(firstName, AsciiType.instance.decompose("pavel"), 1000));
         }});
         rm.build().apply();
 
@@ -1219,23 +1220,23 @@ public class SASIIndexTest
         final ByteBuffer comment = UTF8Type.instance.decompose("comment");
 
         Mutation.PartitionUpdateCollector rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key1"));
-        update(rm, comment, UTF8Type.instance.decompose("ⓈⓅⒺⒸⒾⒶⓁ ⒞⒣⒜⒭⒮ and normal ones"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("ⓈⓅⒺⒸⒾⒶⓁ ⒞⒣⒜⒭⒮ and normal ones"), 1000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key2"));
-        update(rm, comment, UTF8Type.instance.decompose("龍馭鬱"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("龍馭鬱"), 2000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key3"));
-        update(rm, comment, UTF8Type.instance.decompose("インディアナ"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("インディアナ"), 3000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key4"));
-        update(rm, comment, UTF8Type.instance.decompose("レストラン"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("レストラン"), 4000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key5"));
-        update(rm, comment, UTF8Type.instance.decompose("ベンジャミン ウエスト"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("ベンジャミン ウエスト"), 5000);
         rm.build().apply();
 
         if (forceFlush)
@@ -1295,19 +1296,19 @@ public class SASIIndexTest
         final ByteBuffer comment = UTF8Type.instance.decompose("comment_suffix_split");
 
         Mutation.PartitionUpdateCollector rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key1"));
-        update(rm, comment, UTF8Type.instance.decompose("龍馭鬱"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("龍馭鬱"), 1000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key2"));
-        update(rm, comment, UTF8Type.instance.decompose("インディアナ"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("インディアナ"), 2000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key3"));
-        update(rm, comment, UTF8Type.instance.decompose("レストラン"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("レストラン"), 3000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key4"));
-        update(rm, comment, UTF8Type.instance.decompose("ベンジャミン ウエスト"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("ベンジャミン ウエスト"), 4000);
         rm.build().apply();
 
         if (forceFlush)
@@ -1364,7 +1365,7 @@ public class SASIIndexTest
             final ByteBuffer bigValue = UTF8Type.instance.decompose(new String(randomBytes));
 
             Mutation.PartitionUpdateCollector rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key1"));
-            update(rm, comment, bigValue, System.currentTimeMillis());
+            update(rm, comment, bigValue, 1000 + i);
             rm.build().apply();
 
             Set<String> rows;
@@ -1392,7 +1393,7 @@ public class SASIIndexTest
                 put("key4", Pair.create("Jason", 27));
         }};
 
-        ColumnFamilyStore store = loadData(data1, true);
+        ColumnFamilyStore store = loadData(data1, 1000, true);
 
         RowFilter filter = RowFilter.create();
         filter.add(store.metadata().getColumn(firstName), Operator.LIKE_CONTAINS, AsciiType.instance.fromString("a"));
@@ -1444,35 +1445,35 @@ public class SASIIndexTest
         final ByteBuffer fullName = UTF8Type.instance.decompose("/output/full-name/");
 
         Mutation.PartitionUpdateCollector rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key1"));
-        update(rm, fullName, UTF8Type.instance.decompose("美加 八田"), System.currentTimeMillis());
+        update(rm, fullName, UTF8Type.instance.decompose("美加 八田"), 1000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key2"));
-        update(rm, fullName, UTF8Type.instance.decompose("仁美 瀧澤"), System.currentTimeMillis());
+        update(rm, fullName, UTF8Type.instance.decompose("仁美 瀧澤"), 2000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key3"));
-        update(rm, fullName, UTF8Type.instance.decompose("晃宏 高須"), System.currentTimeMillis());
+        update(rm, fullName, UTF8Type.instance.decompose("晃宏 高須"), 3000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key4"));
-        update(rm, fullName, UTF8Type.instance.decompose("弘孝 大竹"), System.currentTimeMillis());
+        update(rm, fullName, UTF8Type.instance.decompose("弘孝 大竹"), 4000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key5"));
-        update(rm, fullName, UTF8Type.instance.decompose("満枝 榎本"), System.currentTimeMillis());
+        update(rm, fullName, UTF8Type.instance.decompose("満枝 榎本"), 5000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key6"));
-        update(rm, fullName, UTF8Type.instance.decompose("飛鳥 上原"), System.currentTimeMillis());
+        update(rm, fullName, UTF8Type.instance.decompose("飛鳥 上原"), 6000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key7"));
-        update(rm, fullName, UTF8Type.instance.decompose("大輝 鎌田"), System.currentTimeMillis());
+        update(rm, fullName, UTF8Type.instance.decompose("大輝 鎌田"), 7000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key8"));
-        update(rm, fullName, UTF8Type.instance.decompose("利久 寺地"), System.currentTimeMillis());
+        update(rm, fullName, UTF8Type.instance.decompose("利久 寺地"), 8000);
         rm.build().apply();
 
         store.forceBlockingFlush();
@@ -1500,15 +1501,15 @@ public class SASIIndexTest
         final ByteBuffer comment = UTF8Type.instance.decompose("address");
 
         Mutation.PartitionUpdateCollector rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key1"));
-        update(rm, comment, UTF8Type.instance.decompose("577 Rogahn Valleys Apt. 178"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("577 Rogahn Valleys Apt. 178"), 1000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key2"));
-        update(rm, comment, UTF8Type.instance.decompose("89809 Beverly Course Suite 089"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("89809 Beverly Course Suite 089"), 2000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key3"));
-        update(rm, comment, UTF8Type.instance.decompose("165 clydie oval apt. 399"), System.currentTimeMillis());
+        update(rm, comment, UTF8Type.instance.decompose("165 clydie oval apt. 399"), 3000);
         rm.build().apply();
 
         if (forceFlush)
@@ -1577,38 +1578,38 @@ public class SASIIndexTest
         Mutation.PartitionUpdateCollector rm;
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key1"));
-        update(rm, name, UTF8Type.instance.decompose("Pavel"), System.currentTimeMillis());
+        update(rm, name, UTF8Type.instance.decompose("Pavel"), 1000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key2"));
-        update(rm, name, UTF8Type.instance.decompose("Jordan"), System.currentTimeMillis());
+        update(rm, name, UTF8Type.instance.decompose("Jordan"), 2000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key3"));
-        update(rm, name, UTF8Type.instance.decompose("Mikhail"), System.currentTimeMillis());
+        update(rm, name, UTF8Type.instance.decompose("Mikhail"), 3000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key4"));
-        update(rm, name, UTF8Type.instance.decompose("Michael"), System.currentTimeMillis());
+        update(rm, name, UTF8Type.instance.decompose("Michael"), 4000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key5"));
-        update(rm, name, UTF8Type.instance.decompose("Johnny"), System.currentTimeMillis());
+        update(rm, name, UTF8Type.instance.decompose("Johnny"), 5000);
         rm.build().apply();
 
         // first flush would make interval for name - 'johnny' -> 'pavel'
         store.forceBlockingFlush();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key6"));
-        update(rm, name, UTF8Type.instance.decompose("Jason"), System.currentTimeMillis());
+        update(rm, name, UTF8Type.instance.decompose("Jason"), 6000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key7"));
-        update(rm, name, UTF8Type.instance.decompose("Vijay"), System.currentTimeMillis());
+        update(rm, name, UTF8Type.instance.decompose("Vijay"), 7000);
         rm.build().apply();
 
         rm = new Mutation.PartitionUpdateCollector(KS_NAME, decoratedKey("key8")); // this name is going to be tokenized
-        update(rm, name, UTF8Type.instance.decompose("Jean-Claude"), System.currentTimeMillis());
+        update(rm, name, UTF8Type.instance.decompose("Jean-Claude"), 8000);
         rm.build().apply();
 
         // this flush is going to produce range - 'jason' -> 'vijay'
@@ -2355,7 +2356,7 @@ public class SASIIndexTest
         ColumnFamilyStore store = loadData(new HashMap<String, Pair<String, Integer>>()
         {{
             put("key1", Pair.create("Pavel", 14));
-        }}, false);
+        }}, 1000, false);
 
         ColumnIndex index = ((SASIIndex) store.indexManager.getIndexByName(store.name + "_first_name")).getIndex();
         IndexMemtable beforeFlushMemtable = index.getCurrentMemtable();
@@ -2386,7 +2387,7 @@ public class SASIIndexTest
         loadData(new HashMap<String, Pair<String, Integer>>()
         {{
             put("key2", Pair.create("Sam", 15));
-        }}, false);
+        }}, 2000, false);
 
         expression = new org.apache.cassandra.index.sasi.plan.Expression(controller, index)
                         .add(Operator.LIKE_MATCHES, UTF8Type.instance.fromString("Sam"));
@@ -2412,7 +2413,7 @@ public class SASIIndexTest
         loadData(new HashMap<String, Pair<String, Integer>>()
         {{
             put("key3", Pair.create("Jonathan", 16));
-        }}, false);
+        }}, 3000, false);
 
         expression = new org.apache.cassandra.index.sasi.plan.Expression(controller, index)
                 .add(Operator.LIKE_MATCHES, UTF8Type.instance.fromString("Jonathan"));
@@ -2491,11 +2492,6 @@ public class SASIIndexTest
                 }
             }
         });
-    }
-
-    private static ColumnFamilyStore loadData(Map<String, Pair<String, Integer>> data, boolean forceFlush)
-    {
-        return loadData(data, System.currentTimeMillis(), forceFlush);
     }
 
     private static ColumnFamilyStore loadData(Map<String, Pair<String, Integer>> data, long timestamp, boolean forceFlush)

--- a/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
+++ b/test/unit/org/apache/cassandra/index/sasi/SASIIndexTest.java
@@ -119,6 +119,7 @@ public class SASIIndexTest
                                     SchemaLoader.clusteringSASICFMD(KS_NAME, CLUSTERING_CF_NAME_2, "location"),
                                     SchemaLoader.staticSASICFMD(KS_NAME, STATIC_CF_NAME),
                                     SchemaLoader.fullTextSearchSASICFMD(KS_NAME, FTS_CF_NAME));
+        stores().forEach(ColumnFamilyStore::disableAutoCompaction);
     }
 
     @Before


### PR DESCRIPTION
The usage of `System.currentTimeMillis()` to generate timestamps is error-prone. Some tests create and apply many mutations in sequence, but sometimes 2 successive mutations get the same timestamp, and the test fails. 

The following tests are potentially impacted by this:

* testCrossSSTableQueries
* testMultiExpressionQueriesWhereRowSplitBetweenSSTables
* testPagination
* testColumnNamesWithSlashes
* testInvalidate
* testIndexRedistribution
* testTruncate
* testSameKeyInMemtableAndSSTables
* testUnicodeSupport
* testUnicodeSuffixModeNoSplits
* testChinesePrefixSearch
* testLowerCaseAnalyzer
* testPrefixSSTableLookup
* testIndexMemtableSwitching